### PR TITLE
conf_general: Changed so rbat hw files are used.

### DIFF
--- a/conf_general.h
+++ b/conf_general.h
@@ -37,8 +37,8 @@
 #define VAR_INIT_CODE				92891935
 
 #if !defined(HW_SOURCE) && !defined(HW_HEADER)
-#define HW_HEADER					"hw_12s7p_v1.h"
-#define HW_SOURCE					"hw_12s7p_v1.c"
+//#define HW_HEADER					"hw_12s7p_v1.h"
+//#define HW_SOURCE					"hw_12s7p_v1.c"
 
 //#define HW_HEADER					"hw_18s_light.h"
 //#define HW_SOURCE					"hw_18s_light.c"
@@ -46,8 +46,8 @@
 //#define HW_HEADER					"hw_stormcore_bms.h"
 //#define HW_SOURCE					"hw_stormcore_bms.c"
 
-//#define HW_HEADER					"hw_rbat_v1.h"
-//#define HW_SOURCE					"hw_rbat_v1.c"
+#define HW_HEADER					"hw_rbat_v1.h"
+#define HW_SOURCE					"hw_rbat_v1.c"
 #endif
 
 /*


### PR DESCRIPTION
Without this change, the rbat won't work.